### PR TITLE
Ember: invoke computed macros directly

### DIFF
--- a/content/ember/alias-model.md
+++ b/content/ember/alias-model.md
@@ -6,14 +6,14 @@ language: ember
 ```javascript
   // Good
   export default Controller.extend({
-    job: computed.alias('model'),
+    job: alias('model'),
 
-    title: computed.alias('job.title'),
+    title: alias('job.title'),
   });
 
   // Bad, implied we're working with a <code>job</code> model
   export default Controller.extend({
-    title: computed.alias('model.title'),
+    title: alias('model.title'),
   });
 ```
 

--- a/content/ember/import-computed-macros.md
+++ b/content/ember/import-computed-macros.md
@@ -1,0 +1,18 @@
+---
+title: Import computed macros directly
+language: ember
+---
+
+```javascript
+  // Good
+  import { alias } from '@ember/object/computed';
+
+  export default Controller.extend({
+    job: alias('model'),
+  });
+
+  // Bad, invoke macro thought computed in logic
+  export default Controller.extend({
+    job: computed.alias('model'),
+  });
+```


### PR DESCRIPTION
We usually use macros directly. 
@Teamtailor/developers what do you think?