### PR TITLE
The right way of how to handle setting of a computed property

### DIFF
--- a/content/ember/setting-computed-properties.md
+++ b/content/ember/setting-computed-properties.md
@@ -7,15 +7,15 @@ This will keep the ability of the property to be still computed
 
 ```javascript
 // Good
-  fullName: computed('firstName', 'lastName', {
-    get(key) {
-      return `${this.get('firstName')} ${this.get('lastName')}`;
-    },
-    set(key, value) {
-      return value;
-    }
-  })
-  set(this, 'fullName', 'Roman Polansky');
+fullName: computed('firstName', 'lastName', {
+  get() {
+    return `${this.get('firstName')} ${this.get('lastName')}`;
+  },
+  set(key, value) {
+    return value;
+  }
+})
+set(this, 'fullName', 'Roman Polansky');
 
 
 // Bad


### PR DESCRIPTION
via https://guides.emberjs.com/v3.0.0/object-model/computed-properties/

Spent 2 days on debugging it. We thought that the setter will do `return value` by default. It didn't. Maybe worth to mention it on style-guide? @Teamtailor/developers 