### PR TITLE
Add .module.scss BEM example

### DIFF
--- a/content/css/bem.md
+++ b/content/css/bem.md
@@ -16,15 +16,33 @@ _Examples - menu item, list item, checkbox caption, header title_
 **Modifier** - A flag on a block or element. Use them to change appearance or behavior.
 _Examples - disabled, highlighted, checked, fixed, size big, color yellow_
 
-```css
-.avatar {
-}
+In `.modules.scss` files 
 
-.avatar__initial {
-}
+1. _Dont add Block, it's added automatically in the output class._
+2. _Use camelCase._
+```scss
+// button.module.scss
 
-.avatar--large {
-}
+.__root {}
+
+.--modifierName {}
+
+.__iconArea--modifierName {}
+```
+
+In `.scss` files 
+
+1. _Prefix with Block_
+2. _Use kebab-case_
+
+```scss
+// button.scss
+
+.button-name__root {}
+
+.button-name--modifier-name {}
+
+.button-name__icon-area--modifier-name {}
 ```
 
 **Great readings**


### PR DESCRIPTION
This is dependant on [this pr](https://github.com/Teamtailor/teamtailor/pull/7016)

I suggest that in `.module.scss` files we switch from using [kebab-case](https://en.wikipedia.org/wiki/Letter_case#cite_ref-30) to separate words in our own naming in BEM classes to using [camelCase](https://en.wikipedia.org/wiki/Camel_case). This way `-` and `_` are only used from BEM semantics and not in our own names. 

This suggestion is to only do it (and lint for it with stylelint) in `.module.scss` files. The current `.scss` files stay the same, with kebab-case.

So instead of `Component-name--modifier-name` we do `ComponentName--modifierName`

## Before
<img width="690" alt="CleanShot 2020-01-21 at 13 19 27@2x" src="https://user-images.githubusercontent.com/351537/72804461-b4683580-3c50-11ea-9677-524d27af1544.png">

## After
<img width="691" alt="CleanShot 2020-01-21 at 13 49 44@2x" src="https://user-images.githubusercontent.com/351537/72806174-e8ddf080-3c54-11ea-800d-2ad963f4ee52.png">


