### PR TITLE
treat all classes not staringing with -- as element classes

### DIFF
--- a/content/css/bem.md
+++ b/content/css/bem.md
@@ -23,11 +23,11 @@ In `.modules.scss` files
 ```scss
 // button.module.scss
 
-.__root {}
+.root {}
 
-.--modifierName {}
+.root--modifierName {}
 
-.__iconArea--modifierName {}
+.root__iconArea--modifierName {}
 ```
 
 In `.scss` files 


### PR DESCRIPTION
No more class names staring with `__` for example: `.__root`.

With this the css modules naming convention is (only removing the starting underscores):

<img width="1017" alt="CleanShot 2020-03-19 at 14 19 45@2x" src="https://user-images.githubusercontent.com/351537/77071648-b5b5a480-69ec-11ea-8df7-f2d7e64c2629.png">

Updateing according to https://github.com/Teamtailor/teamtailor/pull/7761